### PR TITLE
Character map

### DIFF
--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  	<TargetFrameworks>net451;netcoreapp2.1</TargetFrameworks>
+  	<TargetFramework>netcoreapp2.1</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Markdig.Tests/Markdig.Tests.csproj
+++ b/src/Markdig.Tests/Markdig.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-  	<TargetFramework>netcoreapp2.1</TargetFramework>
+  	<TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/src/Markdig/Helpers/CharacterMap.cs
+++ b/src/Markdig/Helpers/CharacterMap.cs
@@ -35,7 +35,9 @@ namespace Markdig.Helpers
             {
                 var openingChar = map.Key;
                 charSet.Add(openingChar);
-                maxChar = Math.Max(maxChar, openingChar);
+
+                if (openingChar < 128)
+                    maxChar = Math.Max(maxChar, openingChar);
             }
 
             OpeningCharacters = charSet.ToArray();

--- a/src/Markdig/Helpers/CharacterMap.cs
+++ b/src/Markdig/Helpers/CharacterMap.cs
@@ -17,8 +17,8 @@ namespace Markdig.Helpers
     public class CharacterMap<T> where T : class
     {
         private readonly T[] asciiMap;
-        private readonly Dictionary<char, T> nonAsciiMap;
-        private readonly BitVector128 isOpeningCharacter;
+        private readonly Dictionary<uint, T> nonAsciiMap;
+        private readonly BoolVector128 isOpeningCharacter;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CharacterMap{T}"/> class.
@@ -27,56 +27,38 @@ namespace Markdig.Helpers
         /// <exception cref="System.ArgumentNullException"></exception>
         public CharacterMap(IEnumerable<KeyValuePair<char, T>> maps)
         {
-            if (maps == null) throw new ArgumentNullException(nameof(maps));
+            if (maps == null) ThrowHelper.ArgumentNullException(nameof(maps));
             var charSet = new HashSet<char>();
             int maxChar = 0;
 
             foreach (var map in maps)
             {
                 var openingChar = map.Key;
-
                 charSet.Add(openingChar);
-
-                if (openingChar < 128 && openingChar > maxChar)
-                {
-                    maxChar = openingChar;
-                }
-                else if (openingChar >= 128 && nonAsciiMap == null)
-                {
-                    // Initialize only if with have an actual non-ASCII opening character
-                    nonAsciiMap = new Dictionary<char, T>();
-                }
+                maxChar = Math.Max(maxChar, openingChar);
             }
+
             OpeningCharacters = charSet.ToArray();
             Array.Sort(OpeningCharacters);
 
             asciiMap = new T[maxChar + 1];
-            var isOpeningCharacter = new BitVector128();
+
+            if (maxChar >= 128)
+                nonAsciiMap = new Dictionary<uint, T>();
 
             foreach (var state in maps)
             {
-                var openingChar = state.Key;
-                T stateByChar;
+                char openingChar = state.Key;
                 if (openingChar < 128)
                 {
-                    stateByChar = asciiMap[openingChar];
-
-                    if (stateByChar == null)
-                    {
-                        asciiMap[openingChar] = state.Value;
-                    }
+                    asciiMap[openingChar] ??= state.Value;
                     isOpeningCharacter.Set(openingChar);
                 }
-                else
+                else if (!nonAsciiMap.ContainsKey(openingChar))
                 {
-                    if (!nonAsciiMap.TryGetValue(openingChar, out stateByChar))
-                    {
-                        nonAsciiMap[openingChar] = state.Value;
-                    }
+                    nonAsciiMap[openingChar] = state.Value;
                 }
             }
-
-            this.isOpeningCharacter = isOpeningCharacter;
         }
 
         /// <summary>
@@ -89,23 +71,25 @@ namespace Markdig.Helpers
         /// </summary>
         /// <param name="openingChar">The opening character.</param>
         /// <returns>A list of parsers valid for the specified opening character or null if no parsers registered.</returns>
-        public T this[char openingChar]
+        public T this[uint openingChar]
         {
-            [MethodImpl(MethodImplOptionPortable.AggressiveInlining)]
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                T map = null;
-                if (openingChar < asciiMap.Length)
+                T[] asciiMap = this.asciiMap;
+                if (openingChar < (uint)asciiMap.Length)
                 {
-                    map = asciiMap[openingChar];
+                    return asciiMap[openingChar];
                 }
-                else if (nonAsciiMap != null)
+                else
                 {
-                    nonAsciiMap.TryGetValue(openingChar, out map);
+                    T map = null;
+                    nonAsciiMap?.TryGetValue(openingChar, out map);
+                    return map;
                 }
-                return map;
             }
         }
+
 
         /// <summary>
         /// Searches for an opening character from a registered parser in the specified string.
@@ -116,57 +100,111 @@ namespace Markdig.Helpers
         /// <returns>Index position within the string of the first opening character found in the specified text; if not found, returns -1</returns>
         public int IndexOfOpeningCharacter(string text, int start, int end)
         {
-            var openingChars = isOpeningCharacter;
-
-            unsafe
+            if (nonAsciiMap is null)
             {
-                fixed (char* pText = text)
+#if NETCOREAPP3_1
+                ref char textRef = ref Unsafe.AsRef(in text.GetPinnableReference());
+                for (; start <= end; start++)
                 {
-                    if (nonAsciiMap == null)
+                    if (IntPtr.Size == 4)
                     {
-                        for (int i = start; i <= end; i++)
+                        uint c = Unsafe.Add(ref textRef, start);
+                        if (c < 128 && isOpeningCharacter[c])
                         {
-                            var c = pText[i];
-                            if (c < 128 && openingChars[c])
-                            {
-                                return i;
-                            }
+                            return start;
                         }
                     }
                     else
                     {
+                        ulong c = Unsafe.Add(ref textRef, start);
+                        if (c < 128 && isOpeningCharacter[c])
+                        {
+                            return start;
+                        }
+                    }
+                }
+#else
+                unsafe
+                {
+                    fixed (char* pText = text)
+                    {
                         for (int i = start; i <= end; i++)
                         {
-                            var c = pText[i];
-                            if (c < 128 ? openingChars[c] : nonAsciiMap.ContainsKey(c))
+                            char c = pText[i];
+                            if (c < 128 && isOpeningCharacter[c])
                             {
                                 return i;
                             }
                         }
                     }
                 }
+#endif
+                return -1;
             }
-            return -1;
+            else
+            {
+                return IndexOfOpeningCharacterNonAscii(text, start, end);
+            }
         }
 
-        internal unsafe struct BitVector128
+        private int IndexOfOpeningCharacterNonAscii(string text, int start, int end)
         {
-            fixed uint values[4];
+#if NETCOREAPP3_1
+            ref char textRef = ref Unsafe.AsRef(in text.GetPinnableReference());
+            for (int i = start; i <= end; i++)
+            {
+                char c = Unsafe.Add(ref textRef, i);
+                if (c < 128 ? isOpeningCharacter[c] : nonAsciiMap.ContainsKey(c))
+                {
+                    return i;
+                }
+            }
+#else
+            unsafe
+            {
+                fixed (char* pText = text)
+                {
+                    for (int i = start; i <= end; i++)
+                    {
+                        char c = pText[i];
+                        if (c < 128 ? isOpeningCharacter[c] : nonAsciiMap.ContainsKey(c))
+                        {
+                            return i;
+                        }
+                    }
+                }
+            }
+#endif
+            return -1;
+        }
+    }
 
-            public void Set(char c)
+    internal unsafe struct BoolVector128
+    {
+        private fixed bool values[128];
+
+        public void Set(char c)
+        {
+            Debug.Assert(c < 128);
+            values[c] = true;
+        }
+
+        public readonly bool this[uint c]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
             {
                 Debug.Assert(c < 128);
-                values[c >> 5] |= (uint)1 << c;
+                return values[c];
             }
-
-            public readonly bool this[char c]
+        }
+        public readonly bool this[ulong c]
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get
             {
-                [MethodImpl(MethodImplOptionPortable.AggressiveInlining)]
-                get
-                {
-                    Debug.Assert(c < 128);
-                    return (values[c >> 5] & (uint)1 << c) != 0;
-                }
+                Debug.Assert(c < 128 && IntPtr.Size == 8);
+                return values[c];
             }
         }
     }

--- a/src/Markdig/Helpers/ThrowHelper.cs
+++ b/src/Markdig/Helpers/ThrowHelper.cs
@@ -10,6 +10,8 @@ namespace Markdig.Helpers
     [ExcludeFromCodeCoverage]
     internal static class ThrowHelper
     {
+        public static void ArgumentNullException(string paramName) => throw new ArgumentNullException(paramName);
+
         public static void ThrowArgumentNullException(ExceptionArgument argument)
         {
             throw new ArgumentNullException(GetArgumentName(argument));

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -6,7 +6,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.18.3</VersionPrefix>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>net35;net40;netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <PackageTags>Markdown CommonMark md html md2html</PackageTags>
     <PackageReleaseNotes>https://github.com/lunet-io/markdig/blob/master/changelog.md</PackageReleaseNotes>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
@@ -23,11 +23,6 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' OR '$(TargetFramework)' == 'net40'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
-    <PackageReference Include="jnm2.ReferenceAssemblies.net35" Version="1.0.1" PrivateAssets="All" />
-  </ItemGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -6,7 +6,7 @@
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>0.18.3</VersionPrefix>
     <Authors>Alexandre Mutel</Authors>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <PackageTags>Markdown CommonMark md html md2html</PackageTags>
     <PackageReleaseNotes>https://github.com/lunet-io/markdig/blob/master/changelog.md</PackageReleaseNotes>
     <PackageLicenseExpression>BSD-2-Clause</PackageLicenseExpression>
@@ -28,6 +28,10 @@
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -36,4 +40,5 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.*" PrivateAssets="All"/>
   </ItemGroup>
+
 </Project>

--- a/src/Markdig/Markdig.targets
+++ b/src/Markdig/Markdig.targets
@@ -20,6 +20,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Memory" Version="4.5.4" />
+  </ItemGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
     <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
   </PropertyGroup>

--- a/src/Markdig/Parsers/ParserList.cs
+++ b/src/Markdig/Parsers/ParserList.cs
@@ -101,7 +101,7 @@ namespace Markdig.Parsers
         /// <param name="openingChar">The opening character.</param>
         /// <returns>A list of parsers valid for the specified opening character or null if no parsers registered.</returns>
         [MethodImpl(MethodImplOptionPortable.AggressiveInlining)]
-        public T[] GetParsersForOpeningCharacter(char openingChar)
+        public T[] GetParsersForOpeningCharacter(uint openingChar)
         {
             return charMap[openingChar];
         }


### PR DESCRIPTION
A quick benchmark on the dataset I use (https://github.com/dotnet/docs/tree/master/docs/core) shows a `35.9` > `34.7` ms change, so ~ 3-3,5%.


The codegen diff for IndexOfOpeningCharacter is

```asm
IndexOfOpeningCharacter(System.String, Int32, Int32)
    L0000: push rdi
    L0001: push rsi
    L0002: push rbp
    L0003: push rbx
    L0004: sub rsp, 0x48
    L0008: vzeroupper
    L000b: mov rsi, rcx
    L000e: lea rdi, [rsp+0x20]
    L0013: mov ecx, 0xa
    L0018: xor eax, eax
    L001a: rep stosd
    L001c: mov rcx, rsi
    L001f: mov rax, 0xb55cfaa848e5
    L0029: mov [rsp+0x40], rax
    L002e: mov esi, r9d
    L0031: mov eax, r8d
    L0034: mov rdi, rcx
    L0037: lea rcx, [rdi+0x20]
    L003b: vmovdqu xmm0, [rcx]
    L003f: vmovdqu [rsp+0x20], xmm0
    L0045: test rdx, rdx
    L0048: jnz L004e
    L004a: xor ebx, ebx
    L004c: jmp L005c
    L004e: add rdx, 0xc
    L0052: mov [rsp+0x38], rdx
    L0057: mov rbx, [rsp+0x38]
    L005c: cmp qword [rdi+0x10], 0x0
    L0061: jnz L00ba
    L0063: cmp eax, esi
    L0065: jg L010b
    L006b: movsxd rcx, eax
    L006e: movzx ecx, word [rbx+rcx*2]
    L0072: cmp ecx, 0x80
    L0078: jge L0092
    L007a: lea rdx, [rsp+0x20]
    L007f: mov r8d, ecx
    L0082: sar r8d, 0x5
    L0086: movsxd r8, r8d
    L0089: mov edx, [rdx+r8*4]
    L008d: bt edx, ecx
    L0090: jb L009a
    L0092: inc eax
    L0094: cmp eax, esi
    L0096: jle L006b
    L0098: jmp L010b
    L009a: mov rcx, 0xb55cfaa848e5
    L00a4: cmp [rsp+0x40], rcx
    L00a9: jz L00b0
    L00ab: call 0x7ffa70dc0780
    L00b0: nop
    L00b1: add rsp, 0x48
    L00b5: pop rbx
    L00b6: pop rbp
    L00b7: pop rsi
    L00b8: pop rdi
    L00b9: ret
    L00ba: mov ebp, eax
    L00bc: cmp ebp, esi
    L00be: jg L010b
    L00c0: movsxd rcx, ebp
    L00c3: movzx edx, word [rbx+rcx*2]
    L00c7: cmp edx, 0x80
    L00cd: jl L00e8
    L00cf: mov rcx, [rdi+0x10]
    L00d3: mov eax, [rcx]
    L00d5: call System.Collections.Generic.Dictionary`2[[System.Char, System.Private.CoreLib],[System.__Canon, System.Private.CoreLib]].FindEntry(Char)
    L00da: test eax, eax
    L00dc: setge al
    L00df: movzx eax, al
    L00e2: test eax, eax
    L00e4: jz L0105
    L00e6: jmp L0137
    L00e8: lea rax, [rsp+0x20]
    L00ed: mov ecx, edx
    L00ef: sar ecx, 0x5
    L00f2: movsxd rcx, ecx
    L00f5: mov eax, [rax+rcx*4]
    L00f8: bt eax, edx
    L00fb: setb al
    L00fe: movzx eax, al
    L0101: test eax, eax
    L0103: jnz L0137
    L0105: inc ebp
    L0107: cmp ebp, esi
    L0109: jle L00c0
    L010b: xor eax, eax
    L010d: mov [rsp+0x38], rax
    L0112: mov eax, 0xffffffff
    L0117: mov rcx, 0xb55cfaa848e5
    L0121: cmp [rsp+0x40], rcx
    L0126: jz L012d
    L0128: call 0x7ffa70dc0780
    L012d: nop
    L012e: add rsp, 0x48
    L0132: pop rbx
    L0133: pop rbp
    L0134: pop rsi
    L0135: pop rdi
    L0136: ret
    L0137: mov eax, ebp
    L0139: mov rcx, 0xb55cfaa848e5
    L0143: cmp [rsp+0x40], rcx
    L0148: jz L014f
    L014a: call 0x7ffa70dc0780
    L014f: nop
    L0150: add rsp, 0x48
    L0154: pop rbx
    L0155: pop rbp
    L0156: pop rsi
    L0157: pop rdi
    L0158: ret
```

PR
```asm
IndexOfOpeningCharacter(System.String, Int32, Int32)
    L0000: cmp qword [rcx+0x10], 0x0
    L0005: jnz L0041
    L0007: mov eax, [rdx]
    L0009: add rdx, 0xc
    L000d: cmp r8d, r9d
    L0010: jg L0037
    L0012: movsxd rax, r8d
    L0015: movzx eax, word [rdx+rax*2]
    L0019: cmp rax, 0x80
    L001f: jae L002f
    L0021: lea r10, [rcx+0x20]
    L0025: cmp [r10], r10d
    L0028: cmp byte [r10+rax], 0x0
    L002d: jnz L003d
    L002f: inc r8d
    L0032: cmp r8d, r9d
    L0035: jle L0012
    L0037: mov eax, 0xffffffff
    L003c: ret
    L003d: mov eax, r8d
    L0040: ret
    L0041: mov rax, 0x7ffa18c500f8
    L004b: jmp rax

IndexOfOpeningCharacterNonAscii(System.String, Int32, Int32)
    L0000: push rdi
    L0001: push rsi
    L0002: push rbp
    L0003: push rbx
    L0004: sub rsp, 0x28
    L0008: mov rdi, rcx
    L000b: mov esi, r9d
    L000e: mov ecx, [rdx]
    L0010: add rdx, 0xc
    L0014: mov rbx, rdx
    L0017: mov ebp, r8d
    L001a: cmp ebp, esi
    L001c: jg L005c
    L001e: movsxd rcx, ebp
    L0021: movzx edx, word [rbx+rcx*2]
    L0025: cmp edx, 0x80
    L002b: jl L0046
    L002d: mov rcx, [rdi+0x10]
    L0031: mov eax, [rcx]
    L0033: call System.Collections.Generic.Dictionary`2[[System.UInt32, System.Private.CoreLib],[System.__Canon, System.Private.CoreLib]].FindEntry(UInt32)
    L0038: test eax, eax
    L003a: setge al
    L003d: movzx eax, al
    L0040: test eax, eax
    L0042: jz L0056
    L0044: jmp L006a
    L0046: lea rax, [rdi+0x20]
    L004a: cmp [rax], eax
    L004c: mov edx, edx
    L004e: movzx eax, byte [rax+rdx]
    L0052: test eax, eax
    L0054: jnz L006a
    L0056: inc ebp
    L0058: cmp ebp, esi
    L005a: jle L001e
    L005c: mov eax, 0xffffffff
    L0061: add rsp, 0x28
    L0065: pop rbx
    L0066: pop rbp
    L0067: pop rsi
    L0068: pop rdi
    L0069: ret
    L006a: mov eax, ebp
    L006c: add rsp, 0x28
    L0070: pop rbx
    L0071: pop rbp
    L0072: pop rsi
    L0073: pop rdi
    L0074: ret
```